### PR TITLE
add ability to control a background process execution

### DIFF
--- a/internal/fork/process.go
+++ b/internal/fork/process.go
@@ -42,10 +42,15 @@ func NewBackgroundProcess(ctx context.Context, command string, opts ...ProcessOp
 }
 
 // Start является аналогом (*exec.Cmd).Start с поддержкой контекста
-func (p *BackgroundProcess) Start(ctx context.Context) error {
+// Также предоставляет возможность контролировать выполнение процесса
+// с помощью канала waitChan
+func (p *BackgroundProcess) Start(ctx context.Context, waitChan ...chan<- error) error {
 	startChan := make(chan error, 1)
 	go func() {
 		startChan <- p.cmd.Start()
+		if len(waitChan) == 1 {
+			waitChan[0] <- p.cmd.Wait()
+		}
 	}()
 
 	for {


### PR DESCRIPTION
**Проблема:**
Если фоновый процесс запускается без ошибки, но в процессе выполнения завершается с ошибкой (например не смог подключиться к БД) - suite об этом ничего не знает и продолжает выполнение, также не выводит stdout, errout логи фонового процесса, что затрудняет поиск ошибок при тестировании.
**Решение:**
Добавить возможность контролировать выполнение фонового процесса, если он завершается с ошибкой - возвращаем ошибку, логи stdout, errout фонового процесса и завершаем тест.